### PR TITLE
ci: enable pre-commit.ci checks in github pull requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
     exclude: '.*\.patch$'
+
+ci:
+  autofix_prs: false
+  autoupdate_commit_msg: 'ci: pre-commit autoupdate'
+  autoupdate_schedule: monthly


### PR DESCRIPTION
This PR enables pre-commit.ci checks. This way we can enforce pre-commit checks before merging any PR