### PR TITLE
fix: set frame rate limit in order to reduce cpu usage

### DIFF
--- a/gui/include/gui.hpp
+++ b/gui/include/gui.hpp
@@ -10,6 +10,7 @@ class Gui
  private:
     static constexpr unsigned int SCENE_WIDTH = 1920;
     static constexpr unsigned int SCENE_HEIGHT = 1080;
+    static constexpr unsigned int MAX_FRAME_RATE = 30;
 
     std::list<Rom> mRomList;
 

--- a/gui/source/gui.cpp
+++ b/gui/source/gui.cpp
@@ -31,6 +31,7 @@ void Gui::run()
 
     sf::RenderWindow window(availableVideoModes[0], std::string(projectName), sf::Style::Fullscreen);
     window.setMouseCursorVisible(false);
+    window.setFramerateLimit(MAX_FRAME_RATE);
     sf::View view(sf::FloatRect(0, 0, SCENE_WIDTH, SCENE_HEIGHT));
     window.setView(view);
 


### PR DESCRIPTION
Up until this moment there was no frame rate limit when rendering our window. This was causing a lot of cpu usage especially on powerful machines. There is now a 30 frame per second limit over our rendering process. This should reduce cpu usage while running the software