### PR TITLE
fix: do not list bios as launchable roms

### DIFF
--- a/lib/source/romsource.cpp
+++ b/lib/source/romsource.cpp
@@ -64,7 +64,11 @@ std::vector<Rom> RomSource::physicalScan() const
     // Physically scanning the folder
     for (auto files = scanResult(mRomFolder); const auto& rom : files.roms)
     {
-        if (auto query = romInfo(rom); query)
+        if (auto query = romInfo(rom); !query || (query->isBios && *(query->isBios)))
+        {
+            spdlog::warn("File: {} does not look like a launchable rom, discarding it", rom.string());
+        }
+        else
         {
             spdlog::trace("Found rom: {}", rom.string());
             RomMedia media;
@@ -83,11 +87,6 @@ std::vector<Rom> RomSource::physicalScan() const
             }
 
             result.emplace_back(rom, *query, media);
-        }
-
-        else
-        {
-            spdlog::warn("File: {} does not look like a launchable rom, discarding it", rom.string());
         }
     }
 


### PR DESCRIPTION
MAME bios were listed among all the other roms as launchables. Bios are not launchable roms so now they are correctly excluded from the list of roms into the gui