### PR TITLE
fix: stop exiting if no rom is found in search folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Roms and screenshots are searched in:
 
 `~/.enea/roms`
 
-You are supposed to fill this folder with roms and screenshot yourself. **If no rom is found Enea will simply exit at startup.** Be sure to provide at least a rom.
+You are supposed to fill this folder with roms and screenshot yourself. Be sure to provide at least a rom.
 
 Control mapping as follows:
 

--- a/gui/source/gui.cpp
+++ b/gui/source/gui.cpp
@@ -47,6 +47,18 @@ void Gui::run()
     RomMenu romMenu(mRomList);
     romMenu.setPosition(ROM_MENU_X, ROM_MENU_Y);
 
+    // Drawing No Rom Found text
+    const float NO_ROM_FOUND_X = view.getSize().x / 2;
+    const float NO_ROM_FOUND_Y = view.getSize().y / 2;
+    TextNode noRomFound;
+    noRomFound.element().setFont(FontManager::get().getResource("fonts/inter.ttf"));
+    noRomFound.element().setCharacterSize(32);
+    noRomFound.element().setString("No rom found");
+    noRomFound.element().setFillColor(sf::Color::Red);
+    noRomFound.element().setOrigin(noRomFound.element().getGlobalBounds().width / 2,
+                                   noRomFound.element().getGlobalBounds().height / 2);
+    noRomFound.element().setPosition(NO_ROM_FOUND_X, NO_ROM_FOUND_Y);
+
     // Creating sounds
     sf::Sound selectionSound;
     selectionSound.setBuffer(SoundManager::get().getResource("audio/move.wav"));
@@ -71,11 +83,14 @@ void Gui::run()
         }
     });
 
-    inputmanager.select.connect([&romMenu, &launchSound]() {
-        launchSound.play();
-        if (auto err = romMenu.launch(); err)
+    inputmanager.select.connect([this, &romMenu, &launchSound]() {
+        if (!mRomList.empty())
         {
-            spdlog::error("Error launching rom: {}", magic_enum::enum_name(*err));
+            launchSound.play();
+            if (auto err = romMenu.launch(); err)
+            {
+                spdlog::error("Error launching rom: {}", magic_enum::enum_name(*err));
+            }
         }
     });
 
@@ -85,7 +100,7 @@ void Gui::run()
 
         window.clear();
         window.draw(programInfo);
-        window.draw(romMenu);
+        mRomList.empty() ? window.draw(noRomFound) : window.draw(romMenu);
         window.display();
     }
 }

--- a/gui/source/rommenu.cpp
+++ b/gui/source/rommenu.cpp
@@ -59,84 +59,88 @@ bool RomMenu::setSelected(const unsigned int selected)
 
 void RomMenu::reorganize()
 {
-    deleteChildren();
-    const unsigned long start = (mSelected / ROWS) * ROWS;
-    // This cast shouldn't be needed but we get compilation errors in armv7hf (?)
-    const unsigned long stop = std::min(static_cast<std::size_t>((mSelected / ROWS) * ROWS + ROWS), mRoms.size());
-
-    std::shared_ptr<TextNode> prev;
-
-    for (unsigned long i = start; i < stop; i++)
+    // No need to do anything if there is no rom to draw
+    if (!mRoms.empty())
     {
-        auto rom = mRoms[i];
-        auto row = std::make_shared<TextNode>();
-        row->element().setString(shortenedRomName(rom));
-        row->element().setFont(mFont);
-        row->element().setCharacterSize(LIST_CHAR_SIZE);
-        i == mSelected ? row->element().setFillColor(sf::Color::White) : row->element().setFillColor(sf::Color::Red);
+        deleteChildren();
+        const unsigned long start = (mSelected / ROWS) * ROWS;
+        // This cast shouldn't be needed but we get compilation errors in armv7hf (?)
+        const unsigned long stop = std::min(static_cast<std::size_t>((mSelected / ROWS) * ROWS + ROWS), mRoms.size());
 
-        // If it is the first element we just attach it with no offset
-        if (!prev)
+        std::shared_ptr<TextNode> prev;
+
+        for (unsigned long i = start; i < stop; i++)
         {
-            addChild(row);
+            auto rom = mRoms[i];
+            auto row = std::make_shared<TextNode>();
+            row->element().setString(shortenedRomName(rom));
+            row->element().setFont(mFont);
+            row->element().setCharacterSize(LIST_CHAR_SIZE);
+            i == mSelected ? row->element().setFillColor(sf::Color::White)
+                           : row->element().setFillColor(sf::Color::Red);
+
+            // If it is the first element we just attach it with no offset
+            if (!prev)
+            {
+                addChild(row);
+            }
+            else
+            {
+                row->setPosition(0, prev->element().getGlobalBounds().height + TEXT_SPACING);
+                prev->addChild(row);
+            }
+
+            prev = row;
         }
-        else
+
+        // Drawing rom info
+        auto rom = mRoms[mSelected];
+        auto nameText = std::make_shared<TextNode>();
+        nameText->element().setString(romName(rom));
+        nameText->element().setFont(mFont);
+        nameText->element().setCharacterSize(INFO_CHAR_SIZE);
+        nameText->element().setFillColor(sf::Color::White);
+        // NOLINTNEXTLINE
+        nameText->setOrigin(nameText->element().getGlobalBounds().width / 2.0F, 0);
+        nameText->setPosition(SCREENSHOT_X_OFFSET, SCREENSHOT_Y_OFFSET);
+        addChild(nameText);
+
+        auto year = rom.year() ? *(rom.year()) : "Unknown Year";
+        auto manufacturer = rom.manufacturer() ? *(rom.manufacturer()) : "Unknown Manufacturer";
+        auto infoText = std::make_shared<TextNode>();
+        infoText->element().setString(fmt::format("{}, {}", year, manufacturer));
+        infoText->element().setFont(mFont);
+        infoText->element().setCharacterSize(INFO_CHAR_SIZE);
+        infoText->element().setFillColor(sf::Color::White);
+        // NOLINTNEXTLINE
+        infoText->setOrigin(infoText->element().getGlobalBounds().width / 2.0F, 0);
+        // NOLINTNEXTLINE
+        infoText->setPosition(nameText->element().getGlobalBounds().width / 2.0F,
+                              nameText->element().getGlobalBounds().height + TEXT_SPACING);
+        nameText->addChild(infoText);
+
+        // Drawing rom screenshot
+        try
         {
-            row->setPosition(0, prev->element().getGlobalBounds().height + TEXT_SPACING);
-            prev->addChild(row);
+            if (auto screenshot = rom.screenshot(); screenshot)
+            {
+                auto screenshotSprite = std::make_shared<SpriteNode>();
+                screenshotSprite->element().setTexture(ScreenShotManager::get().getResource(*screenshot));
+                auto screenshotWidth = screenshotSprite->element().getGlobalBounds().width;
+                auto screenshotHeight = screenshotSprite->element().getGlobalBounds().height;
+                // NOLINTNEXTLINE
+                screenshotSprite->setOrigin(screenshotWidth / 2.0F, 0);
+                // NOLINTNEXTLINE
+                screenshotSprite->setPosition(infoText->element().getGlobalBounds().width / 2.0F,
+                                              infoText->element().getGlobalBounds().height + SCREENSHOT_SPACING);
+                screenshotSprite->scale(SCREENSHOT_WIDTH / screenshotWidth, SCREENSHOT_HEIGHT / screenshotHeight);
+                infoText->addChild(screenshotSprite);
+            }
         }
-
-        prev = row;
-    }
-
-    // Drawing rom info
-    auto rom = mRoms[mSelected];
-    auto nameText = std::make_shared<TextNode>();
-    nameText->element().setString(romName(rom));
-    nameText->element().setFont(mFont);
-    nameText->element().setCharacterSize(INFO_CHAR_SIZE);
-    nameText->element().setFillColor(sf::Color::White);
-    // NOLINTNEXTLINE
-    nameText->setOrigin(nameText->element().getGlobalBounds().width / 2.0F, 0);
-    nameText->setPosition(SCREENSHOT_X_OFFSET, SCREENSHOT_Y_OFFSET);
-    addChild(nameText);
-
-    auto year = rom.year() ? *(rom.year()) : "Unknown Year";
-    auto manufacturer = rom.manufacturer() ? *(rom.manufacturer()) : "Unknown Manufacturer";
-    auto infoText = std::make_shared<TextNode>();
-    infoText->element().setString(fmt::format("{}, {}", year, manufacturer));
-    infoText->element().setFont(mFont);
-    infoText->element().setCharacterSize(INFO_CHAR_SIZE);
-    infoText->element().setFillColor(sf::Color::White);
-    // NOLINTNEXTLINE
-    infoText->setOrigin(infoText->element().getGlobalBounds().width / 2.0F, 0);
-    // NOLINTNEXTLINE
-    infoText->setPosition(nameText->element().getGlobalBounds().width / 2.0F,
-                          nameText->element().getGlobalBounds().height + TEXT_SPACING);
-    nameText->addChild(infoText);
-
-    // Drawing rom screenshot
-    auto screenshotSprite = std::make_shared<SpriteNode>();
-    try
-    {
-        if (auto screenshot = rom.screenshot(); screenshot)
+        catch (const ResourceManager<sf::Texture>::Excep& excep)
         {
-            auto screenshotSprite = std::make_shared<SpriteNode>();
-            screenshotSprite->element().setTexture(ScreenShotManager::get().getResource(*screenshot));
-            auto screenshotWidth = screenshotSprite->element().getGlobalBounds().width;
-            auto screenshotHeight = screenshotSprite->element().getGlobalBounds().height;
-            // NOLINTNEXTLINE
-            screenshotSprite->setOrigin(screenshotWidth / 2.0F, 0);
-            // NOLINTNEXTLINE
-            screenshotSprite->setPosition(infoText->element().getGlobalBounds().width / 2.0F,
-                                          infoText->element().getGlobalBounds().height + SCREENSHOT_SPACING);
-            screenshotSprite->scale(SCREENSHOT_WIDTH / screenshotWidth, SCREENSHOT_HEIGHT / screenshotHeight);
-            infoText->addChild(screenshotSprite);
+            // Don't do anything is no screenshot is available, it's fine
         }
-    }
-    catch (const ResourceManager<sf::Texture>::Excep& excep)
-    {
-        // Don't do anything is no screenshot is available, it's fine
     }
 }
 
@@ -152,6 +156,11 @@ bool RomMenu::selectionUp()
 
 std::optional<Emulator::Error> RomMenu::launch()
 {
+    if (mRoms.empty())
+    {
+        return std::nullopt;
+    }
+
     Emulator emulator;
     return emulator.run(mRoms[mSelected]);
 }


### PR DESCRIPTION
Previous implementation was just exiting at startup (sometimes with also a crash) when no rom was found in the search folder. Now we should be correctly drawing a "No Rom Found" text