### PR TITLE
ci: execute deploy only when main branch is tagged

### DIFF
--- a/.github/workflows/build-tags.yml
+++ b/.github/workflows/build-tags.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build
+    if: github.ref_name == github.event.repository.default_branch
     strategy:
       matrix:
         arch: [x86_64, aarch64, armv7hf]
@@ -24,6 +25,7 @@ jobs:
       contents: write
     runs-on: ubuntu-22.04
     name: Deploy
+    if: github.ref_name == github.event.repository.default_branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
A bug was causing the deploy pipeline to be triggered whenever a tag was pushed (not only on the main branch)